### PR TITLE
Add SystemJs and jspm-cli / Update the ES6 In Depth Articles link to the whole categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Just send a pull request or open an [issue](https://github.com/ericdouglas/ES6-L
 1. [Hanging up on Callbacks: Generators in ECMAScript 6](http://blog.carbonfive.com/2013/12/01/hanging-up-on-callbacks-generators-in-ecmascript-6/)
 1. [ECMASCRIPT 6 – STRING.PROTOTYPE.REPEAT()](http://cwestblog.com/2014/02/27/ecmascript-6-string-prototype-repeat/)
 1. [ECMAScript 6 Classes](http://www.9bitstudios.com/2014/04/ecmascript-6-classes/)
-1. [A collaborative website about the ECMAScript 6](http://es6rocks.com/) 
+1. [A collaborative website about the ECMAScript 6](http://es6rocks.com/)
 1. [Destructuring and Recursion in ES-6](http://raganwald.com/2015/02/02/destructuring.html)
 1. [Tail Calls, Default Arguments, and Excessive Recycling in ES-6](http://raganwald.com/2015/02/07/tail-calls-defult-arguments-recycling.html)
 1. [Lazy Iterables in JavaScript](http://raganwald.com/2015/02/17/lazy-iteratables-in-javascript.html)
-1. [ES6 In Depth: An Introduction](https://hacks.mozilla.org/2015/04/es6-in-depth-an-introduction/)
+1. [ES6 In Depth Articles](https://hacks.mozilla.org/category/es6-in-depth/)
 1. [How to Use ES6 for Isomorphic JavaScript Apps](https://medium.com/javascript-scene/how-to-use-es6-for-isomorphic-javascript-apps-2a9c3abe5ea2)
 1. [ES6 Generators: How do they work?](http://x-team.com/2015/04/generators-work)
-1. [ECMASCript 2015 series on @medium](https://medium.com/ecmascript-2015) 
+1. [ECMASCript 2015 series on @medium](https://medium.com/ecmascript-2015)
 
 ## Books
 
@@ -149,6 +149,8 @@ Just send a pull request or open an [issue](https://github.com/ericdouglas/ES6-L
 1. [shepherd-js](https://github.com/xcambar/shepherd-js) - ES:Harmony compliant module loader and module maker that fits nicely with each and every JS file you can have to work with.
 1. [require-hm](https://github.com/addyosmani/require-hm) - RequireJS loader plugin that supports ES6 Modules.
 1. [es6-module-loader](https://github.com/ModuleLoader/es6-module-loader/) - An ES6 Module Loader polyfill based on the latest spec.
+1. [SystemJS](https://github.com/systemjs/systemjs) - Universal dynamic module loader - loads ES6 modules, AMD, CommonJS and global scripts in the browser and NodeJS. Works with both Traceur and Babel, built on top of the dynamic [ES6 module loader polyfill](https://github.com/ModuleLoader/es6-module-loader/).
+1. [jspm-cli](http://jspm.io/) - jspm is a package manager for the [SystemJS universal module loader](https://github.com/systemjs/systemjs), built on top of the dynamic [ES6 module loader polyfill](https://github.com/ModuleLoader/es6-module-loader/).
 
 ## More Useful Links
 


### PR DESCRIPTION
I added  [SystemJS](https://github.com/systemjs/systemjs), which is built on top of [ES6 module loader polyfill](https://github.com/ModuleLoader/es6-module-loader/), and [jspm-cli](http://jspm.io/), which is a package manager for the SystemJs. 

Moreover, I also updated the link of  [ES6 In Depth Articles](https://hacks.mozilla.org/category/es6-in-depth/) to point to the whole categories instead of pointing to a single introduction page. 